### PR TITLE
Add option b:yaifa_disabled

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -28,5 +28,9 @@ indentation can't be determined:
                         - 1: Tab.
                         - 2: Mixed.
 
+- b:yaifa_disabled      Set this to 1 to disable YAIFA for this buffer.
+                        Can be used in an ftplugin to disable YAIFA for
+                        certain filetypes.
+
 This script is a port to VimL from Philippe Fremy's Python script Indent
 Finder, hence the "Almost" part of the name.

--- a/plugin/yaifa.vim
+++ b/plugin/yaifa.vim
@@ -401,6 +401,10 @@ function! s:results()
 endfunction
 
 function! YAIFA(...)
+        if get(b:, 'yaifa_disabled', 0) != 0
+                return
+        endif
+
         " The magic starts here
         call s:clear()
         call s:parse_file()


### PR DESCRIPTION
I want to disable YAIFA for certain filetypes.

For example, when I open an IRC logfile, I run [this ftplugin](https://github.com/joeytwiddle/rc_files/blob/88b5af90aea08e1549dbd0964e3ac5518ab26411/.vim/ftplugin/irclog.vim) which sets a custom tabstop.

Unfortunately, YAIFA runs after that, and overwrites that tabstop setting!

This PR allows an ftplugin to disable YAIFA for the current file, by doing:

```vim
let b:yaifa_disabled = 1
```

So I can happily run YAIFA everywhere, except in a few special cases.